### PR TITLE
#5chore(config): define DefaultConnection for local BaseDb setup

### DIFF
--- a/src/Server/EventModular.Server.Api/appsettings.json
+++ b/src/Server/EventModular.Server.Api/appsettings.json
@@ -4,6 +4,7 @@
         "Aspire__Comment_1": "Most Aspire resources use Docker, but if team members run Server.Api or Server.Web directly without Docker or wanna using dev tunnels inside Visual Studio, these connection strings ensure functionality.",
         "Aspire__Comment_2": "The EventModular.Tests project runs Server.Web and Server.Api directly, bypassing Aspire, to allow replacing app's registered service in tests, enhancing the test-writing experience. These connection strings are also used by the integration API and UI tests.",
         "SqlServerConnectionString": "Data Source=(localdb)\\mssqllocaldb; Initial Catalog=EventModularDb;Integrated Security=true;Application Name=EventModular;TrustServerCertificate=True;",
+         "DefaultConnection": "Data Source=(localdb)\\ProjectModels;Initial Catalog=BaseDb;Integrated Security=True;Pooling=False;Encrypt=False",
         "ConnectionStrings_Comment": "The ConnectionStrings section contains database connection strings used by the application."
     },
     "Azure": {


### PR DESCRIPTION
Defined a shared DefaultConnection in appsettings.json to serve as the default database for all modular components.  
This ensures consistent database initialization and simplifies local development and integration.
